### PR TITLE
Fix type of time in is_on check, LIGOTimeGPS->float

### DIFF
--- a/pylal/printutils.py
+++ b/pylal/printutils.py
@@ -872,7 +872,7 @@ def printmissed(connection, simulation_table, recovery_table, map_label, livetim
             on_times = coinc_segs[','.join(sorted(on_instruments))]
             
             def is_in_on_time(gps_time, gps_time_ns):
-                return LIGOTimeGPS(gps_time, gps_time_ns) in on_times
+                return gps_time + (1e-9 * gps_time_ns) in on_times
             
             connection.create_function('is_in_on_time', 2, is_in_on_time)
             


### PR DESCRIPTION
At some point the objects in the segmentlist of on times changed from LIGOTimeGPS to float, but the check to see whether a given injection time was in on times still wrapped the time in a LIGOTimeGPS.  The check for 'in' would therefore always fail, resulting in no missed injections being reported, resulting in found/missed plots such as

https://sugar-jobs.phy.syr.edu/~lppekows/pycbc_review/analysis8_ahope-same-harm-exact-nomax-nosubbank_wk1/962582415-963187215/coinc_result_plots//Images/H1L1-ligolw_cbc_plotfm_fm_dist_v_param_ALLINJ_CAT_4_VETO_F1_ALLINJ_PLOTTED-962582415-604800.png

I have confirmed that with this fix the found/missed plots are generated correctly, for example:

https://www.lsc-group.phys.uwm.edu/ligovirgo/cbcnote/Optimization/pycbc_inspiral/merging_cpuopt/revert_investigation?action=AttachFile&do=get&target=ALLINJ_CAT4_FM_OLD_CODE.png
