### PR TITLE
Fix for conflation of inj sets with similar tags

### DIFF
--- a/bin/pylal_cbc_cohptf_injcombiner
+++ b/bin/pylal_cbc_cohptf_injcombiner
@@ -190,10 +190,10 @@ def main( injCacheFile, outdir, maxIncl , injString , verbose=False ):
   # construct output filename
   ifoTag = foundcache[0].observatory
   start, end = foundcache.to_segmentlistdict().extent_all()
-
   userTag = injcache[0].description.rsplit('_', 2)[0]
   xmlFile = '%s/%s-%s_%s_FILTERED_%d_FOUND-%d-%d.xml'\
-            % ( outdir, ifoTag, userTag, injString, maxIncl, start, end-start )
+            % (outdir, ifoTag, userTag, injString.split(str(int(maxIncl)))[0],
+               maxIncl, start, end-start )
 
   start,end = map( int, foundcache[0].segment )
 


### PR DESCRIPTION
This change allows for a more robust use of injection set tags in the GRB workflow, to stop different sets being conflated in post processing.