### PR TITLE
Set to release 0.9.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def write_build_info():
     pylal/git_version.py.
     """
     date = branch = tag = author = committer = status = builder_name = build_date = ""
-    id = "1.0.dev0"
+    id = "0.9.6"
     
     try:
         v = gvcsi.generate_git_version_info()
@@ -118,7 +118,8 @@ setup(
     author = 'Ligo Virgo Collaboration - PyCBC team',
     author_email = 'alex.nitz@ligo.org',
     url = 'https://github.com/ligo-cbc/pycbc-pylal',
-    release = False,
+    download_url = 'https://github.com/a-r-williamson/pycbc-pylal/archive/v0.9.6.tar.gz',
+    release = True,
     description = "legacy support python ligo algorithm library",
     license = "See file LICENSE",
     cmdclass = {'install' : pylal_install,},


### PR DESCRIPTION
The 1.4.0 release of PyCBC will need a new release of this project to be built against.