### PR TITLE
Move import into function to avoid xlal import

### DIFF
--- a/pylal/imr_utils.py
+++ b/pylal/imr_utils.py
@@ -20,7 +20,6 @@ from glue.ligolw import dbtables
 from glue import segments
 from glue import segmentsUtils
 from glue.ligolw import table
-from pylal import db_thinca_rings
 from pylal import rate
 import numpy
 import math
@@ -186,6 +185,7 @@ def get_instruments_from_coinc_event_table(connection):
 
 
 def get_segments(connection, xmldoc, table_name, live_time_program, veto_segments_name = None, data_segments_name = "datasegments"):
+	from pylal import db_thinca_rings
 	segs = segments.segmentlistdict()
 
 	if table_name == dbtables.lsctables.CoincInspiralTable.tableName:


### PR DESCRIPTION
Pylal's xlal stuff is annoying because it links PyLAL to a specific version of lalsuite. I think the only place it is currently imported in the workflow is sensitivity.py for the pylal rate estimation. However, an xlal import is not actually used here, so if one pushes the import of db_thinca_rings to where it is actually needed (which for us is "never") then we avoid the problem.

I think this fixes the issue that has been reported (by @tdent ?) on atlas of:

```
  File &quot;/home/spxiwh/lscsoft_git/executables_pycbc_master/lib/python2.7/site-packages/PyCBC-80b57-py2.7.egg/pycbc/sensitivity.py&quot;, line 192, in volume_binned_pylal
    from pylal.imr_utils import compute_search_volume_in_bins, compute_search_efficiency_in_bins
  File &quot;/home/spxiwh/lscsoft_git/executables_pycbc_master/lib/python2.7/site-packages/pylal/imr_utils.py&quot;, line 23, in &lt;module&gt;
    from pylal import db_thinca_rings
  File &quot;/home/spxiwh/lscsoft_git/executables_pycbc_master/lib/python2.7/site-packages/pylal/db_thinca_rings.py&quot;, line 36, in &lt;module&gt;
    from pylal import SnglInspiralUtils
  File &quot;/home/spxiwh/lscsoft_git/executables_pycbc_master/lib/python2.7/site-packages/pylal/SnglInspiralUtils.py&quot;, line 28, in &lt;module&gt;
    from pylal.xlal.datatypes.ligotimegps import LIGOTimeGPS
ImportError: liblal.so.11: cannot open shared object file: No such file or directory
```