### PR TITLE
Changing import of glue to pycbc_glue

### DIFF
--- a/pylal/legacy_ihope.py
+++ b/pylal/legacy_ihope.py
@@ -31,7 +31,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope.html
 
 import os
 import urlparse
-from glue import segments
+from pycbc_glue import segments
 from pycbc.workflow.core import Executable, File, FileList, Node
 
 


### PR DESCRIPTION
Hi @spxiwh,

I believe we need to change this import to keep in line with `pycbc`, is that correct?

Andrew