### PR TITLE
Cohptf post proc bugs

### DIFF
--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -583,17 +583,14 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         if val > bestNR:
           numTrialsLouder += 1
     FAP = numTrialsLouder/totalTrials
-    pval = '< %.3g' % (1./totalTrials) if FAP==0 else '%.3g' % FAP
-
-    # Get null SNR of trigger
-    nullsnr = trig.get_null_snr()
+    pval = '< %.3g' % (1./totalTrials) if FAP==0 else '%.3g' % FAP 
 
     d = [ '%s-%s' % tuple(trigBin), chunkNum, trigSlideID, pval,\
           '%.4f' % trig.get_end(),\
           '%.2f' % trig.mass1, '%.2f' % trig.mass2, '%.2f' % trig.mchirp,\
           '%.2f' % (np.degrees(trig.ra)), '%.2f'% (np.degrees(trig.dec)),\
           '%.2f' % trig.snr, '%.2f' % trig.chisq, '%.2f' % trig.bank_chisq,\
-          '%.2f' % trig.cont_chisq, '%.2f' % nullsnr ]
+          '%.2f' % trig.cont_chisq, '%.2f' % trig.get_null_snr() ]
     d.extend([ '%.2f' % getattr(trig,'snr_%s' % ifoAtt[ifo])\
                for ifo in ifos ])
     d.extend([ slideDict[trigSlideID][ifo] for ifo in ifos])
@@ -757,7 +754,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
              trig.mass1, trig.mass2, trig.mchirp,\
              np.degrees(trig.ra), np.degrees(trig.dec),\
              trig.snr, trig.chisq, trig.bank_chisq,\
-             trig.cont_chisq, nullsnr] + \
+             trig.cont_chisq, trig.get_null_snr()] + \
             [trig.get_sngl_snr(ifo) for ifo in ifos] + [loudOnBestNR[bin[0]]]
         file2.write('%s\n' % pval.replace('<', '&lt'))
         td.append(d)

--- a/bin/pylal_cbc_cohptf_injfinder
+++ b/bin/pylal_cbc_cohptf_injfinder
@@ -70,7 +70,7 @@ coh_PTF_injfinder will find and record found and missed injections for the given
 
   parser.add_argument("-o", "--output-dir", action="store", type=str,
                       default=os.getcwd(), help="output directory, "
-                                               "default: %default")
+                                               "default: %(default)s")
 
   parser.add_argument("-W", "--time-window", action="store", type=float,
                      default=0, help="The found time window")
@@ -85,7 +85,7 @@ coh_PTF_injfinder will find and record found and missed injections for the given
                      "if any SpinTaylor injections failed and remove them. If"
                      " not set, no injections will be removed.")
   parser.add_argument("-V", "--verbose", action="store_true", default=False,
-                     help="verbose output, default: %default")
+                     help="verbose output, default: %(default)s")
 
   args = parser.parse_args()
 


### PR DESCRIPTION
This fixes
1. The broken `pylal_cbc_cohptf_injfinder --help`
2. The null SNR reported on all loudest_event.html's.  The value being reported everywhere (including the onsource result page!) was the null SNR of the 30th loudest offsource trigger.